### PR TITLE
Add POST user test with comments

### DIFF
--- a/src/test/java/com/example/ApiTest.java
+++ b/src/test/java/com/example/ApiTest.java
@@ -8,16 +8,54 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class ApiTest {
 
+    /**
+     * Simple test for the GET users endpoint.
+     * <p>
+     * Sends a request to <code>/api/users?page=2</code> and verifies that the
+     * service responds with HTTP 200 and that the returned page number is 2.
+     */
     @Test
     void getUsersPage2() {
+        // Base URI used for all requests
         RestAssured.baseURI = "https://reqres.in";
+
+        // Perform GET request with query parameter "page=2"
         given()
             .queryParam("page", 2)
         .when()
             .get("/api/users")
         .then()
+            .log().body()            // Log the body for debugging
+            .statusCode(200)        // Verify HTTP status is 200 OK
+            .body("page", equalTo(2)); // Assert that the page field equals 2
+    }
+
+    /**
+     * Example POST request to create a user.
+     *
+     * Sends the JSON payload <code>{"name":"morpheus","job":"leader"}</code>
+     * to <code>/api/users</code> and expects HTTP 201 in response.
+     */
+    @Test
+    void createUser() {
+        RestAssured.baseURI = "https://reqres.in";
+
+        // JSON body to send in the request
+        String requestBody = "{\n" +
+                "    \"name\": \"morpheus\",\n" +
+                "    \"job\": \"leader\"\n" +
+                "}";
+
+        // Perform POST request with the body and validate the response
+        given()
+            .header("Content-Type", "application/json")
+            .body(requestBody)
+        .when()
+            .post("/api/users")
+        .then()
             .log().body()
-            .statusCode(200)
-            .body("page", equalTo(2));
+            .statusCode(201)        // Expect HTTP 201 Created
+            .body("name", equalTo("morpheus"))
+            .body("job", equalTo("leader"));
     }
 }


### PR DESCRIPTION
## Summary
- document existing GET user test with inline comments
- add POST user creation test

## Testing
- `mvn test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68610564250083278210c49ce21b51c4