### PR TITLE
Add register successful test

### DIFF
--- a/src/test/java/com/example/ApiTest.java
+++ b/src/test/java/com/example/ApiTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class ApiTest {
 
@@ -19,5 +20,22 @@ public class ApiTest {
             .log().body()
             .statusCode(200)
             .body("page", equalTo(2));
+    }
+
+    @Test
+    void registerSuccessful() {
+        RestAssured.baseURI = "https://reqres.in";
+        String requestBody = "{\"email\":\"eve.holt@reqres.in\",\"password\":\"pistol\"}";
+
+        given()
+            .header("Content-Type", "application/json")
+            .body(requestBody)
+        .when()
+            .post("/api/register")
+        .then()
+            .log().body()
+            .statusCode(200)
+            .body("id", notNullValue())
+            .body("token", notNullValue());
     }
 }


### PR DESCRIPTION
## Summary
- add a test that verifies the Register Successful API on reqres.in

## Testing
- `mvn -q test` *(fails: Could not transfer artifact due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68610ab33a588327876df36285a27f47